### PR TITLE
Update FalkorDB image to v0.1.5-beta.20

### DIFF
--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -46,7 +46,7 @@ echo "$token" | docker login "$registry_host" -u barak --password-stdin || {
 
 echo "✅ Successfully logged into Docker registry!"
 
-FALKORDB_IMAGE="text-to-cypher:v0.1.5-beta.17"   # source image to pull
+FALKORDB_IMAGE="text-to-cypher:v0.1.5-beta.20"   # source image to pull
 TARGET_IMAGE_NAME="falkordb_server"              # image name expected by falkordb.yml
 TARGET_TAG="latest"                              # falkordb.yml has no tag -> defaults to 'latest'
 


### PR DESCRIPTION
Fix Snowflake security scan failure by upgrading from v0.1.5-beta.17 (redis 7.4.2 with CVE-2025-46817) to v0.1.5-beta.20 (redis 8.2.2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database infrastructure component to a newer release version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->