### PR TITLE
feat: expose FalkorDB Browser endpoint publicly

### DIFF
--- a/app/src/falkordb.yaml
+++ b/app/src/falkordb.yaml
@@ -26,4 +26,4 @@ spec:
       public: false
     - name: falkordb-browser
       port: 3000
-      public: false
+      public: true

--- a/app/src/manifest.yml
+++ b/app/src/manifest.yml
@@ -5,7 +5,7 @@ version:
   name: V2
   label: "Version Two"
   comment: "Use MERGE for idempotent sample data loading and update documentation with MERGE examples"
-  patch: 18
+  patch: 19
 
 
 #artifacts that are distributed from this version of the package


### PR DESCRIPTION
## Summary

Set the `falkordb-browser` endpoint (port 3000) to `public: true` so it is accessible via Snowflake's ingress URL.

## Changes

- **`app/src/falkordb.yaml`** — changed `falkordb-browser` endpoint from `public: false` to `public: true`
- **`app/src/manifest.yml`** — bumped patch version to 19

## Consumer Setup

After installing/upgrading the app, the consumer must grant the bind privilege:

```sql
GRANT BIND SERVICE ENDPOINT ON ACCOUNT TO APPLICATION <app_name>;
```

The browser URL can then be discovered with:

```sql
SHOW ENDPOINTS IN SERVICE app_public.st_spcs;
```

The URL follows the pattern: `<hash>-<service>-falkordb-browser.<region>.snowflakecomputing.app`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FalkorDB browser endpoint is now publicly accessible.

* **Chores**
  * Version update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->