### PR TITLE
Expose browser endpoint in Snowflake service

### DIFF
--- a/app/src/falkordb.yaml
+++ b/app/src/falkordb.yaml
@@ -2,6 +2,8 @@ spec:
   containers:
     - name: falkordb-server
       image: /falkordb_app/napp/img_repo/falkordb_server:latest
+      env:
+        NEXTAUTH_URL: auto
       volumeMounts:
         - name: shared-staging
           mountPath: /var/lib/FalkorDB/import
@@ -26,4 +28,4 @@ spec:
       public: false
     - name: falkordb-browser
       port: 3000
-      public: false
+      public: true

--- a/app/src/falkordb.yaml
+++ b/app/src/falkordb.yaml
@@ -4,6 +4,8 @@ spec:
       image: /falkordb_app/napp/img_repo/falkordb_server:latest
       env:
         NEXTAUTH_URL: auto
+        AUTH_TRUST_HOST: "true"
+        TRUST_PROXY_HEADERS: "true"
       volumeMounts:
         - name: shared-staging
           mountPath: /var/lib/FalkorDB/import

--- a/app/src/manifest.yml
+++ b/app/src/manifest.yml
@@ -4,8 +4,8 @@ manifest_version: 1
 version:
   name: V2
   label: "Version Two"
-  comment: "Use MERGE for idempotent sample data loading and update documentation with MERGE examples"
-  patch: 18
+  comment: "Expose FalkorDB Browser through a public Snowpark Container Services endpoint"
+  patch: 19
 
 
 #artifacts that are distributed from this version of the package

--- a/app/src/manifest.yml
+++ b/app/src/manifest.yml
@@ -4,8 +4,8 @@ manifest_version: 1
 version:
   name: V2
   label: "Version Two"
-  comment: "Expose FalkorDB Browser through a public Snowpark Container Services endpoint"
-  patch: 19
+  comment: "Trust Snowpark proxy headers for FalkorDB Browser authentication"
+  patch: 20
 
 
 #artifacts that are distributed from this version of the package

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -73,6 +73,13 @@ $$;
 GRANT USAGE ON PROCEDURE app_public.copy_bound_table_to_stage(VARCHAR) TO APPLICATION ROLE app_admin;
 GRANT USAGE ON PROCEDURE app_public.copy_bound_table_to_stage(VARCHAR) TO APPLICATION ROLE app_user;
 
+-- Store FalkorDB engine version (updated each release via docker_push.sh)
+CREATE TABLE IF NOT EXISTS app_public.app_metadata (key STRING, value STRING);
+MERGE INTO app_public.app_metadata t USING (SELECT 'falkordb_version' AS key, 'text-to-cypher:v0.1.5-beta.20' AS value) s
+  ON t.key = s.key WHEN MATCHED THEN UPDATE SET value = s.value WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.value);
+GRANT SELECT ON TABLE app_public.app_metadata TO APPLICATION ROLE app_admin;
+GRANT SELECT ON TABLE app_public.app_metadata TO APPLICATION ROLE app_user;
+
 -- Create staging area for CSV exports
 CREATE STAGE IF NOT EXISTS app_public.staging;
 GRANT READ, WRITE ON STAGE app_public.staging TO APPLICATION ROLE app_admin;

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -75,7 +75,7 @@ GRANT USAGE ON PROCEDURE app_public.copy_bound_table_to_stage(VARCHAR) TO APPLIC
 
 -- Store FalkorDB engine version (updated each release via docker_push.sh)
 CREATE TABLE IF NOT EXISTS app_public.app_metadata (key STRING, value STRING);
-MERGE INTO app_public.app_metadata t USING (SELECT 'falkordb_version' AS key, 'text-to-cypher:v0.1.5-beta.20' AS value) s
+MERGE INTO app_public.app_metadata t USING (SELECT 'falkordb_version' AS key, 'text-to-cypher:v0.1.12' AS value) s
   ON t.key = s.key WHEN MATCHED THEN UPDATE SET value = s.value WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.value);
 GRANT SELECT ON TABLE app_public.app_metadata TO APPLICATION ROLE app_admin;
 GRANT SELECT ON TABLE app_public.app_metadata TO APPLICATION ROLE app_user;

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -1,5 +1,5 @@
 echo "Getting repository information using JSON format..."
-json_output=$(snow sql --format JSON -q "use role falkordb_role; show image repositories in schema falkordb_app.napp;" 2>/dev/null)
+json_output=$(snow sql --format JSON -q "show image repositories in schema falkordb_app.napp;" 2>/dev/null)
 
 if [ $? -ne 0 ] || [ -z "$json_output" ]; then
     echo "❌ Failed to get repository information from Snowflake"
@@ -7,7 +7,7 @@ if [ $? -ne 0 ] || [ -z "$json_output" ]; then
 fi
 
 # Extract repository URL using jq - handle nested JSON structure
-repository_url=$(echo "$json_output" | jq -r '.[1][0].repository_url // empty' 2>/dev/null)
+repository_url=$(echo "$json_output" | jq -r '.[0].repository_url // .[1][0].repository_url // empty' 2>/dev/null)
 
 if [ ! -z "$repository_url" ] && [[ "$repository_url" =~ .*registry\.snowflakecomputing\.com.* ]]; then
     echo "✅ Extracted repository URL: $repository_url"
@@ -19,28 +19,11 @@ else
     exit 1
 fi
 
-# Log in to Docker registry using local token file
-echo "🔐 Logging into Docker registry using local token..."
+# Log in to Docker registry using the active Snowflake CLI connection
+echo "🔐 Logging into Docker registry using Snowflake CLI..."
 
-# Extract registry host from repository URL
-registry_host=$(echo "$repository_url" | sed 's|/.*||')
-
-# Read token from local file
-if [ ! -f "token" ]; then
-    echo "❌ Token file not found. Please ensure 'token' file exists in the project root."
-    exit 1
-fi
-
-token=$(head -n 1 token)
-
-if [ -z "$token" ]; then
-    echo "❌ Token file is empty or invalid."
-    exit 1
-fi
-
-# Login with token from file
-echo "$token" | docker login "$registry_host" -u barak --password-stdin || {
-	echo "❌ Docker login failed with token from file. Please check your token and credentials."
+snow spcs image-registry login --connection myconnection || {
+	echo "❌ Docker login failed through Snowflake CLI. Please check your Snowflake connection."
 	exit 1
 }
 
@@ -69,18 +52,19 @@ docker push "$repository_url/$TARGET_IMAGE_NAME:$TARGET_TAG" || {
 # List images currently present in the Snowflake image repository
 echo "📦 Listing images in Snowflake repository..."
 repo_fqn="falkordb_app.napp.img_repo"
-images_json=$(snow sql --format JSON -q "use role falkordb_role; use database falkordb_app; show images in image repository ${repo_fqn};" 2>/dev/null)
+images_json=$(snow sql --format JSON -q "show images in image repository ${repo_fqn};" 2>/dev/null)
 
 if [ $? -ne 0 ] || [ -z "$images_json" ]; then
     echo "⚠️ Could not retrieve images list from repository $repo_fqn"
 else
     # Try to render a compact table if expected fields exist, otherwise print raw JSON
     pretty_list=$(echo "$images_json" | jq -r '
-        if (.[1] | length) == 0 then "(no images found)"
-        else (.[1] | map([.repository_name // .repository // "",
-                          .tag // .image_tag // "",
-                          .digest // .image_digest // "",
-                          .created_on // .last_modified // ""]) 
+        (if (.[1]? | type) == "array" then .[1] else . end) as $rows |
+        if ($rows | length) == 0 then "(no images found)"
+        else ($rows | map([.repository_name // .repository // "",
+                           .tag // .image_tag // "",
+                           .digest // .image_digest // "",
+                           .created_on // .last_modified // ""])
         | ( ["REPOSITORY","TAG","DIGEST","CREATED"], ["----------","---","------","-------"] ) + .
         | .[] | @tsv) end' 2>/dev/null)
 
@@ -92,4 +76,3 @@ else
 fi
 
 echo "✅ Pushed image reference to use in YAML: /falkordb_app/napp/img_repo/${TARGET_IMAGE_NAME}:${TARGET_TAG}"
-

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -46,7 +46,7 @@ echo "$token" | docker login "$registry_host" -u barak --password-stdin || {
 
 echo "✅ Successfully logged into Docker registry!"
 
-FALKORDB_IMAGE="text-to-cypher:v0.1.5-beta.20"   # source image to pull
+FALKORDB_IMAGE="text-to-cypher:v0.1.12"          # source image to pull
 TARGET_IMAGE_NAME="falkordb_server"              # image name expected by falkordb.yml
 TARGET_TAG="latest"                              # falkordb.yml has no tag -> defaults to 'latest'
 
@@ -92,5 +92,4 @@ else
 fi
 
 echo "✅ Pushed image reference to use in YAML: /falkordb_app/napp/img_repo/${TARGET_IMAGE_NAME}:${TARGET_TAG}"
-
 

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -50,6 +50,11 @@ FALKORDB_IMAGE="text-to-cypher:v0.1.5-beta.20"   # source image to pull
 TARGET_IMAGE_NAME="falkordb_server"              # image name expected by falkordb.yml
 TARGET_TAG="latest"                              # falkordb.yml has no tag -> defaults to 'latest'
 
+# Auto-update FalkorDB version in setup.sql so the app knows its own version
+SETUP_SQL="$(dirname "$0")/../app/src/setup.sql"
+sed -i '' "s|'falkordb_version', '[^']*'|'falkordb_version', '${FALKORDB_IMAGE}'|g" "$SETUP_SQL"
+echo "✅ Updated setup.sql with falkordb_version=${FALKORDB_IMAGE}"
+
 docker pull --platform linux/amd64 "falkordb/$FALKORDB_IMAGE" || {
 	echo "❌ Failed to pull FalkorDB Docker image: \"falkordb/$FALKORDB_IMAGE"
 	exit 1


### PR DESCRIPTION
## Summary
- set `NEXTAUTH_URL=auto` for the Snowflake service container
- make the `falkordb-browser` endpoint public so Snowflake allocates an ingress URL

## Validation
- parsed `app/src/falkordb.yaml` successfully as YAML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * FalkorDB Browser is now publicly accessible via a dedicated endpoint.

* **Chores**
  * Updated FalkorDB engine to v0.1.12.
  * Bumped application version to v0.1.19.
  * Enhanced configuration and metadata management infrastructure.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FalkorDB/snowflake-integration/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->