### PR TITLE
Support multi-file CSV loading for bound tables

### DIFF
--- a/app/src/readme.md
+++ b/app/src/readme.md
@@ -124,6 +124,15 @@ CALL <app_instance_name>.app_public.load_csv(
 **Note**:
 - The table is automatically retrieved from your Config UI binding—no need to specify it as a parameter
 - The Cypher query must include `LOAD CSV FROM 'file://...' AS row` to access the CSV data via `row[0]`, `row[1]`, etc.
+- The file name in the `file://...` clause is a placeholder; the app passes the actual staged CSV filename to the FalkorDB service for each load.
+- Large tables can be exported as multiple CSV parts. The app loads each part sequentially, so use idempotent Cypher such as `MERGE` for reload-safe imports.
+- If the bound table has no rows, `load_csv` returns an empty array and does not call the FalkorDB load endpoint.
+
+#### Multi-part CSV staging behavior
+
+`load_csv` exports the bound table into a unique folder under `@app_public.staging`. Snowflake may write one CSV file or split a large export into multiple part files. The app lists that folder, validates the generated file names, sorts them lexicographically for deterministic retries, and copies each part to the stage root before calling the FalkorDB service. The root copy preserves the existing service contract: `load_csv_raw` receives a flat `csv_file` name mounted at `/var/lib/FalkorDB/import`, not a nested stage path.
+
+After loading, the app removes both the temporary folder and the root-level copies. Cleanup failures are returned as errors so leaked staged files are visible. Multi-part loads are sequential, not transactional across all parts; if one part loads and a later part fails, the graph changes from the earlier part remain. Use `MERGE` or delete/recreate the graph when retrying loads that must be idempotent, and do not rely on source row order across generated part files.
 
 ### Step 6: Query Your Graph
 
@@ -188,7 +197,7 @@ The FalkorDB app provides the following SQL procedures for graph management and 
 **`load_csv(graph_name VARCHAR, cypher_query VARCHAR)`**
 - Imports data from your bound table (configured during installation) into a graph structure
 - Uses the table reference you selected in the Config UI
-- Automatically stages data, loads it into FalkorDB, and cleans up temporary files
+- Automatically stages data, loads one or more CSV parts into FalkorDB, and cleans up temporary files
 - Example: `CALL app_public.load_csv('my_graph', 'LOAD CSV FROM ''file://consumer_data.csv'' AS row MERGE (n:Node {prop: row[0]})');`
 - **Note**: The Cypher query must include `LOAD CSV FROM 'file://...' AS row` clause to access CSV columns via `row[0]`, `row[1]`, etc.
 
@@ -245,8 +254,8 @@ FalkorDB operates entirely within your Snowflake environment using Snowpark Cont
    - Creates wrapper procedures for graph operations
 
 3. **Data Loading**: When you call `load_csv()`, the app:
-   - Exports your specified Snowflake table to a CSV file in a staging area
-   - Mounts the CSV file to the FalkorDB container
+   - Exports your specified Snowflake table to one or more CSV files in a staging area
+   - Mounts the CSV files to the FalkorDB container
    - Executes your Cypher query to map CSV data into graph structures
    - Automatically cleans up temporary files
 

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -54,6 +54,9 @@ GRANT USAGE ON PROCEDURE app_public.check_bound_table() TO APPLICATION ROLE app_
 GRANT USAGE ON PROCEDURE app_public.check_bound_table() TO APPLICATION ROLE app_user;
 
 -- Helper procedure to copy bound table data to stage
+-- The caller owns the stage folder lifecycle. This helper only writes the
+-- bound-table export into the supplied folder so direct callers cannot
+-- accidentally delete pre-existing staged files.
 CREATE OR REPLACE PROCEDURE app_public.copy_bound_table_to_stage(stage_folder VARCHAR)
 RETURNS VARCHAR
 LANGUAGE SQL
@@ -63,13 +66,10 @@ $$
 DECLARE
   invalid_stage_folder EXCEPTION (-20001, 'Invalid stage folder name');
 BEGIN
-  IF (NOT REGEXP_LIKE(stage_folder, '^[A-Za-z0-9_-]+$')) THEN
+  IF (stage_folder IS NULL OR NOT REGEXP_LIKE(stage_folder, '^[A-Za-z0-9_-]+$')) THEN
     RAISE invalid_stage_folder;
   END IF;
 
-  -- Ensure retries or extremely unlikely folder reuse cannot load stale part files.
-  EXECUTE IMMEDIATE 'REMOVE @app_public.staging/' || :stage_folder || '/';
-  
   -- Copy data directly from the reference (no need to query alias)
   EXECUTE IMMEDIATE 'COPY INTO @app_public.staging/' || :stage_folder || '/' ||
                     ' FROM reference(''consumer_data_table'')' ||
@@ -159,15 +159,53 @@ BEGIN
         ENDPOINT=''api''
         AS ''/load_csv''';
     
-    -- Create wrapper procedure for load_csv, load the data from bound consumer_table reference as csv file to staging area and then call load_csv_raw
+    -- Create wrapper procedure for load_csv, load the data from bound consumer_table reference as csv files to staging area and then call load_csv_raw
     EXECUTE IMMEDIATE 'CREATE OR REPLACE PROCEDURE app_public.load_csv(graph_name VARCHAR, cypher_query VARCHAR)
         RETURNS VARIANT
         LANGUAGE JAVASCRIPT
         AS
         ''
+        /*
+         * Multi-part staging flow:
+         * 1. Export the bound table into a UUID-named folder under app_public.staging.
+         *    COPY INTO may create multiple CSV part files for large tables.
+         * 2. LIST the folder, validate each generated basename, and sort the names
+         *    for deterministic retry behavior.
+         * 3. COPY FILES each part back to the stage root before calling load_csv_raw.
+         *    The FalkorDB service already expects csv_file to be a flat filename in
+         *    /var/lib/FalkorDB/import, so nested stage paths are intentionally hidden.
+         *    INCLUDE_QUERY_ID in COPY INTO keeps these root filenames unique across
+         *    concurrent load_csv calls.
+         * 4. Remove both the temporary folder and root copies. Cleanup failures are
+         *    surfaced to the caller so leaked stage files are visible.
+         */
         var uuidResult = snowflake.execute({sqlText: "SELECT REPLACE(UUID_STRING(), ''''-'''', ''''_'''')"});
         uuidResult.next();
         var stageFolder = "consumer_data_" + uuidResult.getColumnValue(1);
+        var rootCsvFiles = [];
+
+        function removeStagePath(path) {
+            snowflake.execute({sqlText: "REMOVE " + path});
+        }
+
+        function cleanupTemporaryFiles() {
+            var cleanupErrors = [];
+            try {
+                removeStagePath("@app_public.staging/" + stageFolder + "/");
+            } catch (folderErr) {
+                cleanupErrors.push("folder cleanup failed: " + folderErr.message);
+            }
+
+            for (var i = 0; i < rootCsvFiles.length; i++) {
+                try {
+                    removeStagePath("@app_public.staging/" + rootCsvFiles[i]);
+                } catch (fileErr) {
+                    cleanupErrors.push("file cleanup failed for " + rootCsvFiles[i] + ": " + fileErr.message);
+                }
+            }
+
+            return cleanupErrors;
+        }
 
         // Export bound table data to CSV part files using helper procedure
         try {
@@ -183,7 +221,12 @@ BEGIN
                 throw new Error(exportStatus);
             }
         } catch (err) {
-            throw new Error("Failed to export data from bound table. Ensure a table is bound in the app configuration. Error: " + err.message);
+            var exportCleanupErrors = cleanupTemporaryFiles();
+            var exportMessage = "Failed to export data from bound table. Ensure a table is bound in the app configuration. Error: " + err.message;
+            if (exportCleanupErrors.length > 0) {
+                exportMessage += " Cleanup also failed: " + exportCleanupErrors.join("; ");
+            }
+            throw new Error(exportMessage);
         }
         
         try {
@@ -191,41 +234,59 @@ BEGIN
                 sqlText: "LIST @app_public.staging/" + stageFolder + "/"
             });
 
+            var stagedFiles = [];
             var loadResults = [];
             while (listResult.next()) {
                 var stagedName = listResult.getColumnValue(1);
                 var folderPrefix = stageFolder + "/";
-                var folderIndex = stagedName.indexOf(folderPrefix);
+                var folderIndex = stagedName.lastIndexOf(folderPrefix);
                 if (folderIndex < 0) {
                     throw new Error("Unexpected staged file path: " + stagedName);
                 }
-                var csvFilename = stagedName.substring(folderIndex);
+                var csvFilename = stagedName.substring(folderIndex + folderPrefix.length);
+                if (!/^[A-Za-z0-9_.-]+$/.test(csvFilename)) {
+                    throw new Error("Unexpected staged file name: " + csvFilename);
+                }
+                stagedFiles.push(csvFilename);
+            }
 
+            if (stagedFiles.length === 0) {
+                var emptyCleanupErrors = cleanupTemporaryFiles();
+                if (emptyCleanupErrors.length > 0) {
+                    throw new Error("No rows were exported, and cleanup failed: " + emptyCleanupErrors.join("; "));
+                }
+                return [];
+            }
+
+            stagedFiles.sort();
+
+            // Root filenames stay invocation-unique because COPY INTO uses INCLUDE_QUERY_ID.
+            for (var copyIndex = 0; copyIndex < stagedFiles.length; copyIndex++) {
+                var rootCsvFilename = stagedFiles[copyIndex];
+                rootCsvFiles.push(rootCsvFilename);
+                snowflake.execute({
+                    sqlText: "COPY FILES INTO @app_public.staging FROM @app_public.staging/" + stageFolder + "/ FILES = (''" + rootCsvFilename + "'')"
+                });
+            }
+
+            for (var loadIndex = 0; loadIndex < rootCsvFiles.length; loadIndex++) {
                 var result = snowflake.execute({
                     sqlText: "SELECT app_public.load_csv_raw({''''graph_name'''': ?, ''''csv_file'''': ?, ''''cypher_query'''': ?})",
-                    binds: [GRAPH_NAME, csvFilename, CYPHER_QUERY]
+                    binds: [GRAPH_NAME, rootCsvFiles[loadIndex], CYPHER_QUERY]
                 });
                 loadResults.push(result.next() ? result.getColumnValue(1) : null);
             }
 
-            if (loadResults.length === 0) {
-                throw new Error("No CSV part files were exported for the bound table.");
+            var cleanupErrors = cleanupTemporaryFiles();
+            if (cleanupErrors.length > 0) {
+                throw new Error("Loaded CSV data but failed to clean up temporary stage files: " + cleanupErrors.join("; "));
             }
-
-            // Clean up CSV part files
-            snowflake.execute({
-                sqlText: "REMOVE @app_public.staging/" + stageFolder + "/"
-            });
             
             return loadResults.length === 1 ? loadResults[0] : loadResults;
         } catch (err) {
-            // Clean up on error
-            try {
-                snowflake.execute({
-                    sqlText: "REMOVE @app_public.staging/" + stageFolder + "/"
-                });
-            } catch (cleanupErr) {
-                // Ignore cleanup errors
+            var errorCleanupErrors = cleanupTemporaryFiles();
+            if (errorCleanupErrors.length > 0) {
+                throw new Error(err.message + " Cleanup also failed: " + errorCleanupErrors.join("; "));
             }
             throw err;
         }

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -265,7 +265,7 @@ BEGIN
                 var rootCsvFilename = stagedFiles[copyIndex];
                 rootCsvFiles.push(rootCsvFilename);
                 snowflake.execute({
-                    sqlText: "COPY FILES INTO @app_public.staging FROM @app_public.staging/" + stageFolder + "/ FILES = (''" + rootCsvFilename + "'')"
+                    sqlText: "COPY FILES INTO @app_public.staging FROM @app_public.staging/" + stageFolder + "/ FILES = (''''" + rootCsvFilename + "'''')"
                 });
             }
 

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -63,7 +63,7 @@ $$
 DECLARE
   invalid_stage_folder EXCEPTION (-20001, 'Invalid stage folder name');
 BEGIN
-  IF (NOT REGEXP_LIKE(:stage_folder, '^[A-Za-z0-9_-]+$')) THEN
+  IF (NOT REGEXP_LIKE(stage_folder, '^[A-Za-z0-9_-]+$')) THEN
     RAISE invalid_stage_folder;
   END IF;
 

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -54,16 +54,27 @@ GRANT USAGE ON PROCEDURE app_public.check_bound_table() TO APPLICATION ROLE app_
 GRANT USAGE ON PROCEDURE app_public.check_bound_table() TO APPLICATION ROLE app_user;
 
 -- Helper procedure to copy bound table data to stage
-CREATE OR REPLACE PROCEDURE app_public.copy_bound_table_to_stage(csv_filename VARCHAR)
+CREATE OR REPLACE PROCEDURE app_public.copy_bound_table_to_stage(stage_folder VARCHAR)
 RETURNS VARCHAR
 LANGUAGE SQL
 EXECUTE AS OWNER
-AS $$
+AS
+$$
+DECLARE
+  invalid_stage_folder EXCEPTION (-20001, 'Invalid stage folder name');
 BEGIN
+  IF (NOT REGEXP_LIKE(:stage_folder, '^[A-Za-z0-9_-]+$')) THEN
+    RAISE invalid_stage_folder;
+  END IF;
+
+  -- Ensure retries or extremely unlikely folder reuse cannot load stale part files.
+  EXECUTE IMMEDIATE 'REMOVE @app_public.staging/' || :stage_folder || '/';
+  
   -- Copy data directly from the reference (no need to query alias)
-  EXECUTE IMMEDIATE 'COPY INTO @app_public.staging/' || :csv_filename ||
+  EXECUTE IMMEDIATE 'COPY INTO @app_public.staging/' || :stage_folder || '/' ||
                     ' FROM reference(''consumer_data_table'')' ||
-                    ' FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE) SINGLE = TRUE';
+                    ' FILE_FORMAT = (TYPE = CSV COMPRESSION = NONE)' ||
+                    ' INCLUDE_QUERY_ID = TRUE';
   RETURN 'Success';
 EXCEPTION
   WHEN OTHER THEN
@@ -154,37 +165,64 @@ BEGIN
         LANGUAGE JAVASCRIPT
         AS
         ''
-        var randomId = Math.abs(Math.floor(Math.random() * 1000000));
-        var csvFilename = "consumer_data_" + randomId + ".csv";
+        var uuidResult = snowflake.execute({sqlText: "SELECT REPLACE(UUID_STRING(), ''''-'''', ''''_'''')"});
+        uuidResult.next();
+        var stageFolder = "consumer_data_" + uuidResult.getColumnValue(1);
 
-        // Export bound table data to CSV using helper procedure
+        // Export bound table data to CSV part files using helper procedure
         try {
-            snowflake.execute({
+            var exportResult = snowflake.execute({
                 sqlText: "CALL app_public.copy_bound_table_to_stage(?)",
-                binds: [csvFilename]
+                binds: [stageFolder]
             });
+            if (!exportResult.next()) {
+                throw new Error("Export helper returned no result.");
+            }
+            var exportStatus = exportResult.getColumnValue(1);
+            if (typeof exportStatus === "string" && exportStatus.indexOf("ERROR:") === 0) {
+                throw new Error(exportStatus);
+            }
         } catch (err) {
             throw new Error("Failed to export data from bound table. Ensure a table is bound in the app configuration. Error: " + err.message);
         }
         
         try {
-            // Call load_csv_raw
-            var result = snowflake.execute({
-                sqlText: "SELECT app_public.load_csv_raw({''''graph_name'''': ?, ''''csv_file'''': ?, ''''cypher_query'''': ?})",
-                binds: [GRAPH_NAME, csvFilename, CYPHER_QUERY]
+            var listResult = snowflake.execute({
+                sqlText: "LIST @app_public.staging/" + stageFolder + "/"
             });
-            
-            // Clean up CSV file
+
+            var loadResults = [];
+            while (listResult.next()) {
+                var stagedName = listResult.getColumnValue(1);
+                var folderPrefix = stageFolder + "/";
+                var folderIndex = stagedName.indexOf(folderPrefix);
+                if (folderIndex < 0) {
+                    throw new Error("Unexpected staged file path: " + stagedName);
+                }
+                var csvFilename = stagedName.substring(folderIndex);
+
+                var result = snowflake.execute({
+                    sqlText: "SELECT app_public.load_csv_raw({''''graph_name'''': ?, ''''csv_file'''': ?, ''''cypher_query'''': ?})",
+                    binds: [GRAPH_NAME, csvFilename, CYPHER_QUERY]
+                });
+                loadResults.push(result.next() ? result.getColumnValue(1) : null);
+            }
+
+            if (loadResults.length === 0) {
+                throw new Error("No CSV part files were exported for the bound table.");
+            }
+
+            // Clean up CSV part files
             snowflake.execute({
-                sqlText: "REMOVE @app_public.staging/" + csvFilename
+                sqlText: "REMOVE @app_public.staging/" + stageFolder + "/"
             });
             
-            return result.next() ? result.getColumnValue(1) : null;
+            return loadResults.length === 1 ? loadResults[0] : loadResults;
         } catch (err) {
             // Clean up on error
             try {
                 snowflake.execute({
-                    sqlText: "REMOVE @app_public.staging/" + csvFilename
+                    sqlText: "REMOVE @app_public.staging/" + stageFolder + "/"
                 });
             } catch (cleanupErr) {
                 // Ignore cleanup errors
@@ -378,4 +416,3 @@ END
 $$;
 GRANT USAGE ON PROCEDURE app_public.load_sample_social_network() TO APPLICATION ROLE app_admin;
 GRANT USAGE ON PROCEDURE app_public.load_sample_social_network() TO APPLICATION ROLE app_user;
-

--- a/docs/SNOWFLAKE_INTEGRATION_GUIDE.md
+++ b/docs/SNOWFLAKE_INTEGRATION_GUIDE.md
@@ -94,7 +94,20 @@ CALL <app_instance_name>.app_public.load_csv(
 - The table is automatically retrieved from your Config UI binding—no need to specify it as a parameter
 - The Cypher query must include `LOAD CSV FROM 'file://consumer_data.csv' AS row` to access the CSV data
 - Access columns using `row[0]`, `row[1]`, `row[2]`, etc. (0-indexed)
+- The file name in the `file://...` clause is a placeholder; the app passes the actual staged CSV filename to the FalkorDB service for each load.
 - Use MERGE instead of CREATE to safely reload data without duplicates
+- Large bound tables can be exported as multiple CSV parts. The app loads each part sequentially, sorted lexicographically by staged file name.
+- If the bound table has no rows, `load_csv` returns an empty array and does not call the FalkorDB load endpoint.
+
+### Multi-part CSV staging behavior
+
+`load_csv` exports the bound table into a unique folder under `@app_public.staging`. Snowflake may write one CSV file or split a large export into multiple part files. The app lists that folder, validates each generated filename, sorts the names lexicographically for deterministic retries, and copies each part to the stage root before calling the FalkorDB service.
+
+The stage-root copy is intentional. The container mounts `@app_public.staging` at `/var/lib/FalkorDB/import`, and the existing `load_csv_raw` service contract expects `csv_file` to be a flat filename in that import directory. The generated folder path is kept internal to the Snowflake wrapper so existing Cypher examples with `LOAD CSV FROM 'file://consumer_data.csv'` continue to work as a placeholder while the service receives the actual staged filename for each part.
+
+After loading, the app removes both the temporary export folder and the root-level copies used by the service. If cleanup fails, `load_csv` returns an error that includes the cleanup failure instead of silently leaving files behind. If the bound table has no rows, there are no part files to load; the procedure removes the temporary folder and returns `[]`.
+
+Multi-part loads are sequential and are not rolled back as a single unit. If one part succeeds and a later part fails, graph changes from the successful part remain. Prefer idempotent `MERGE` queries for retry-safe imports, and avoid relying on source row order across generated part files.
 
 ### Querying Graphs
 
@@ -283,6 +296,8 @@ CALL <app_instance_name>.app_public.load_csv(
 **CREATE vs MERGE**:
 - **CREATE**: Always creates new nodes (use for one-time bulk loads)
 - **MERGE**: Matches existing or creates new (use for incremental updates)
+
+Large bound tables may load as multiple CSV parts. If one part succeeds and a later part fails, already-loaded graph changes are not rolled back, so prefer idempotent `MERGE` queries for any load that may be retried.
 
 **Alternative**: If you need to fully replace data, delete and recreate:
 


### PR DESCRIPTION
## Summary
- export bound tables to unique stage folders instead of a single CSV file
- load each exported CSV part through the FalkorDB load endpoint
- add safe folder validation and exact-folder cleanup

## Notes
- committed only app/src/setup.sql
- untracked local files were left out of the commit

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Export now uses folder-based staging for multi-part outputs; stage folder names are validated and not pre-cleaned.
  * Part files are copied to a flat stage root, loaded sequentially, and results are aggregated (single value returned when only one part).
  * Temporary staging artifacts are removed on success or failure; partial loads are not atomically rolled back.

* **Documentation**
  * Expanded docs describing multi-part staging, load sequencing, cleanup/error semantics, idempotent reload guidance, and empty-result behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->