### PR TITLE
Associate HubSpot contacts with subscriptions

### DIFF
--- a/metrics/export_metrics.py
+++ b/metrics/export_metrics.py
@@ -8,7 +8,8 @@ Sources:
   - APPLICATION_STATE  → cloud_region, cloud_vendor, cloud_version,
                           hs_recurring_billing_start_date, hs_status,
                           db_name, cloud_db_name, hs_name, hs_last_modified_at
-  - LISTING_EVENTS_DAILY → deployment_type, subscription_plan, email
+  - LISTING_EVENTS_DAILY → deployment_type, subscription_plan, email,
+                            first_name, last_name
 
 Hardcoded (no Snowflake source):
   - cloud_provider = "snowflake"
@@ -141,7 +142,8 @@ def query_application_state(cursor, listing_filter):
 def query_listing_events(cursor, listing_filter):
     """Pull per-consumer event data from LISTING_EVENTS_DAILY.
 
-    Fields used for: deployment_type, subscription_plan, email.
+    Fields used for: deployment_type, subscription_plan, email, first_name,
+    last_name.
     """
     return run_query(
         cursor,
@@ -150,7 +152,9 @@ def query_listing_events(cursor, listing_filter):
             consumer_account_locator,
             consumer_account_name,
             event_type,
-            consumer_email
+            consumer_email,
+            consumer_metadata:first_name::string AS first_name,
+            consumer_metadata:last_name::string AS last_name
         FROM snowflake.data_sharing_usage.listing_events_daily
         WHERE listing_name LIKE %s
           AND event_type IN ('GET', 'TRIAL', 'PURCHASE')
@@ -247,6 +251,10 @@ def build_subscriptions(app_state_rows, events_rows, falkordb_version):
         # Prefer rows that have email
         if row.get("consumer_email") and not events_by_locator[locator].get("consumer_email"):
             events_by_locator[locator]["consumer_email"] = row["consumer_email"]
+        if row.get("first_name") and not events_by_locator[locator].get("first_name"):
+            events_by_locator[locator]["first_name"] = row["first_name"]
+        if row.get("last_name") and not events_by_locator[locator].get("last_name"):
+            events_by_locator[locator]["last_name"] = row["last_name"]
 
     subscriptions = []
     for install in app_state_rows:
@@ -279,6 +287,8 @@ def build_subscriptions(app_state_rows, events_rows, falkordb_version):
             "hs_last_modified_at": transform_date(last_upgraded) or transform_date(created_on),
             "subscription_plan": transform_subscription_plan(event_type),
             "email": event_row.get("consumer_email") or "",
+            "first_name": event_row.get("first_name") or "",
+            "last_name": event_row.get("last_name") or "",
         }
         subscriptions.append(subscription)
 

--- a/metrics/push_to_hubspot.py
+++ b/metrics/push_to_hubspot.py
@@ -12,6 +12,10 @@ HubSpot fields pushed per consumer:
   subscription_id_omnistrate, deployment_type, hs_last_modified_at,
   subscription_plan, email
 
+HubSpot associations:
+  If a consumer email is available, the script upserts a contact and associates
+  it to the subscription so it appears under Contacts on the subscription record.
+
 Required env var:
   HUBSPOT_ACCESS_TOKEN - Private App token from HubSpot
 
@@ -37,6 +41,7 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 HUBSPOT_BASE = "https://api.hubapi.com"
+SUBSCRIPTION_TO_CONTACT_ASSOCIATION_TYPE_ID = 295
 
 # HubSpot subscription fields we manage. Keep legacy names and add aliases
 # used by the current HubSpot record layout.
@@ -179,6 +184,88 @@ def upsert_subscription(token: str, properties: dict) -> str:
         return new_id
 
 
+def search_contact(token: str, email: str) -> str | None:
+    """Find an existing contact by email."""
+    url = f"{HUBSPOT_BASE}/crm/v3/objects/contacts/search"
+    payload = {
+        "filterGroups": [
+            {
+                "filters": [
+                    {
+                        "propertyName": "email",
+                        "operator": "EQ",
+                        "value": email,
+                    }
+                ]
+            }
+        ],
+        "properties": ["email"],
+        "limit": 1,
+    }
+    resp = requests.post(url, headers=_headers(token), json=payload, timeout=15)
+    resp.raise_for_status()
+    results = resp.json().get("results", [])
+    return results[0]["id"] if results else None
+
+
+def upsert_contact(token: str, sub: dict) -> str:
+    """Create or update a HubSpot contact. Returns the contact id."""
+    email = str(sub.get("email") or "").strip()
+    if not email:
+        raise ValueError("Cannot upsert contact without email")
+
+    properties = {"email": email}
+    if sub.get("first_name"):
+        properties["firstname"] = str(sub["first_name"])
+    if sub.get("last_name"):
+        properties["lastname"] = str(sub["last_name"])
+
+    existing_id = search_contact(token, email)
+    if existing_id:
+        url = f"{HUBSPOT_BASE}/crm/v3/objects/contacts/{existing_id}"
+        update_properties = {k: v for k, v in properties.items() if k != "email"}
+        if update_properties:
+            resp = requests.patch(
+                url,
+                headers=_headers(token),
+                json={"properties": update_properties},
+                timeout=15,
+            )
+            if not resp.ok:
+                log.error("HubSpot contact PATCH error %s: %s", resp.status_code, resp.text)
+            resp.raise_for_status()
+        log.info("Upserted contact for subscription '%s' (id=%s)", sub.get("hs_name", ""), existing_id)
+        return existing_id
+
+    url = f"{HUBSPOT_BASE}/crm/v3/objects/contacts"
+    resp = requests.post(url, headers=_headers(token), json={"properties": properties}, timeout=15)
+    if not resp.ok:
+        log.error("HubSpot contact POST error %s: %s", resp.status_code, resp.text)
+    resp.raise_for_status()
+    new_id = resp.json()["id"]
+    log.info("Created contact for subscription '%s' (id=%s)", sub.get("hs_name", ""), new_id)
+    return new_id
+
+
+def associate_contact_to_subscription(token: str, subscription_id: str, contact_id: str) -> None:
+    """Associate a contact with a subscription using HubSpot's defined type."""
+    url = (
+        f"{HUBSPOT_BASE}/crm/v4/objects/subscriptions/{subscription_id}"
+        f"/associations/contacts/{contact_id}"
+    )
+    payload = [
+        {
+            "associationCategory": "HUBSPOT_DEFINED",
+            "associationTypeId": SUBSCRIPTION_TO_CONTACT_ASSOCIATION_TYPE_ID,
+        }
+    ]
+    resp = requests.put(url, headers=_headers(token), json=payload, timeout=15)
+    if not resp.ok:
+        log.error("HubSpot association error %s: %s", resp.status_code, resp.text)
+    resp.raise_for_status()
+    log.info("Associated subscription id=%s with contact id=%s", subscription_id, contact_id)
+
+
 # ---------------------------------------------------------------------------
 # Main logic
 # ---------------------------------------------------------------------------
@@ -198,7 +285,11 @@ def push_subscriptions(token: str, subscriptions: list[dict]) -> None:
 
         # Only send the fields we manage.
         properties = {field: str(sub.get(field, "")) for field in SUBSCRIPTION_FIELDS}
-        upsert_subscription(token, properties)
+        subscription_id = upsert_subscription(token, properties)
+
+        if sub.get("email"):
+            contact_id = upsert_contact(token, sub)
+            associate_contact_to_subscription(token, subscription_id, contact_id)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary
- export consumer first and last names from Snowflake listing metadata
- upsert HubSpot contacts by consumer email
- associate contacts to subscription records using HubSpot association type 295

## Validation
- python -m py_compile metrics/export_metrics.py metrics/push_to_hubspot.py