### PR TITLE
V2 patch 48: text-to-cypher v0.2.6 (timeout fix), FalkorDB query timeouts, shortest_path & page_rank procedures

### DIFF
--- a/app/src/falkordb.yaml
+++ b/app/src/falkordb.yaml
@@ -9,6 +9,9 @@ spec:
       env:
         AUTH_TRUST_HOST: "true"
         TRUST_PROXY_HEADERS: "true"
+        # FalkorDB 4.20+ applies query timeouts to writes too; give loads room
+        # (TIMEOUT_DEFAULT) and cap runaway queries (TIMEOUT_MAX).
+        FALKORDB_ARGS: "MAX_QUEUED_QUERIES 25 TIMEOUT_DEFAULT 60000 TIMEOUT_MAX 120000 RESULTSET_SIZE 10000"
       volumeMounts:
         - name: shared-staging
           mountPath: /var/lib/FalkorDB/import

--- a/app/src/manifest.yml
+++ b/app/src/manifest.yml
@@ -4,8 +4,8 @@ manifest_version: 1
 version:
   name: V2
   label: "Version Two"
-  comment: "Add FalkorDB Cortex Agent integration"
-  patch: 42
+  comment: "Set FalkorDB query timeouts (TIMEOUT_DEFAULT 60s, TIMEOUT_MAX 120s) so large loads succeed and runaway queries are capped"
+  patch: 48
 
 
 #artifacts that are distributed from this version of the package

--- a/app/src/readme.md
+++ b/app/src/readme.md
@@ -356,24 +356,6 @@ CALL <app_instance_name>.app_public.page_rank(
 );
 ```
 
-**`shortest_path(graph_name VARCHAR, node_label VARCHAR, node_prop VARCHAR, source_value VARCHAR, target_value VARCHAR, rel_type VARCHAR, weight_prop VARCHAR)`**
-- Finds the weighted shortest path between two nodes using FalkorDB's `algo.SPpaths` (Dijkstra)
-- Minimizes the sum of a numeric relationship property (distance, time, price) along the path
-- Returns `pathWeight` (total of the minimized property) and `route` (node property values along the path)
-- Example:
-
-```sql
-CALL <app_instance_name>.app_public.shortest_path(
-    'airroutes',      -- graph name
-    'Airport',        -- node label
-    'iata_code',      -- node property to match and display
-    'SYD',            -- source value
-    'JFK',            -- target value
-    'ROUTE',          -- relationship type
-    'distance_km'     -- numeric relationship property to minimize
-);
-```
-
 ### Cortex Agent Integration
 
 The agent is created after the normal FalkorDB setup flow. It does not start the service by itself. It can load data only from an already-bound `consumer_data_table` reference after the user confirms the generated LOAD CSV mapping.

--- a/app/src/readme.md
+++ b/app/src/readme.md
@@ -322,6 +322,58 @@ The app must have permission to create the output table in the target schema:
 GRANT CREATE TABLE ON SCHEMA AIRROUTES_DB.RESULTS TO APPLICATION <app_instance_name>;
 ```
 
+**`shortest_path(graph_name VARCHAR, node_label VARCHAR, node_prop VARCHAR, source_value VARCHAR, target_value VARCHAR, rel_type VARCHAR, weight_prop VARCHAR)`**
+- Finds the weighted shortest path between two nodes using FalkorDB's `algo.SPpaths` (Dijkstra)
+- Minimizes the sum of a numeric relationship property (distance, time, price) along the path
+- Returns `pathWeight` (total of the minimized property) and `route` (node property values along the path)
+- Example:
+
+```sql
+CALL <app_instance_name>.app_public.shortest_path(
+    'airroutes',      -- graph name
+    'Airport',        -- node label
+    'iata_code',      -- node property to match and display
+    'SYD',            -- source value
+    'JFK',            -- target value
+    'ROUTE',          -- relationship type
+    'distance_km'     -- numeric relationship property to minimize
+);
+```
+
+**`page_rank(graph_name VARCHAR, node_label VARCHAR, rel_type VARCHAR, node_prop VARCHAR, limit_count INTEGER)`**
+- Ranks nodes by importance using FalkorDB's `algo.pageRank`: a node ranks high when many other important nodes point to it
+- Returns the top `limit_count` nodes with their scores, highest first
+- Answers questions like "which airports are most critical to the network?" or "which customer/product/server matters most if it fails?"
+- Example:
+
+```sql
+CALL <app_instance_name>.app_public.page_rank(
+    'airroutes',   -- graph name
+    'Airport',     -- node label
+    'ROUTE',       -- relationship type
+    'iata_code',   -- node property to display
+    10             -- how many top nodes to return
+);
+```
+
+**`shortest_path(graph_name VARCHAR, node_label VARCHAR, node_prop VARCHAR, source_value VARCHAR, target_value VARCHAR, rel_type VARCHAR, weight_prop VARCHAR)`**
+- Finds the weighted shortest path between two nodes using FalkorDB's `algo.SPpaths` (Dijkstra)
+- Minimizes the sum of a numeric relationship property (distance, time, price) along the path
+- Returns `pathWeight` (total of the minimized property) and `route` (node property values along the path)
+- Example:
+
+```sql
+CALL <app_instance_name>.app_public.shortest_path(
+    'airroutes',      -- graph name
+    'Airport',        -- node label
+    'iata_code',      -- node property to match and display
+    'SYD',            -- source value
+    'JFK',            -- target value
+    'ROUTE',          -- relationship type
+    'distance_km'     -- numeric relationship property to minimize
+);
+```
+
 ### Cortex Agent Integration
 
 The agent is created after the normal FalkorDB setup flow. It does not start the service by itself. It can load data only from an already-bound `consumer_data_table` reference after the user confirms the generated LOAD CSV mapping.

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -424,6 +424,27 @@ BEGIN
     EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.shortest_path(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR) TO APPLICATION ROLE app_admin';
     EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.shortest_path(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR) TO APPLICATION ROLE app_user';
 
+    -- Create wrapper procedure for PageRank (algo.pageRank). Scores every
+    -- node by importance: a node ranks high when many other important nodes
+    -- point to it. Returns the top limit_count nodes with their scores,
+    -- highest first, showing node_prop for each node.
+    EXECUTE IMMEDIATE 'CREATE OR REPLACE PROCEDURE app_public.page_rank(graph_name VARCHAR, node_label VARCHAR, rel_type VARCHAR, node_prop VARCHAR, limit_count INTEGER)
+        RETURNS STRING
+        LANGUAGE SQL
+        AS
+        ''DECLARE
+            cypher STRING;
+        BEGIN
+            cypher := ''''CALL algo.pageRank("'''' || :node_label || ''''", "'''' || :rel_type || ''''") '''' ||
+                      ''''YIELD node, score '''' ||
+                      ''''RETURN node.'''' || :node_prop || '''' AS node, score '''' ||
+                      ''''ORDER BY score DESC LIMIT '''' || :limit_count;
+            RETURN app_public.graph_query_raw({''''graph_name'''': :graph_name, ''''query'''': :cypher});
+        END''';
+
+    EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.page_rank(VARCHAR, VARCHAR, VARCHAR, VARCHAR, INTEGER) TO APPLICATION ROLE app_admin';
+    EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.page_rank(VARCHAR, VARCHAR, VARCHAR, VARCHAR, INTEGER) TO APPLICATION ROLE app_user';
+
     -- Cortex Agent tool functions. Cortex Agents call these as generic tools
     -- from Snowflake; the functions delegate to the app-owned SPCS service.
     EXECUTE IMMEDIATE 'CREATE OR REPLACE FUNCTION agent_tools.get_context(input_agent_name VARCHAR)

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -663,6 +663,7 @@ var spec = `spec:
       env:
         AUTH_TRUST_HOST: "true"
         TRUST_PROXY_HEADERS: "true"
+        FALKORDB_ARGS: "MAX_QUEUED_QUERIES 25 TIMEOUT_DEFAULT 60000 TIMEOUT_MAX 120000 RESULTSET_SIZE 10000"
       volumeMounts:
         - name: shared-staging
           mountPath: /var/lib/FalkorDB/import

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -118,7 +118,7 @@ GRANT USAGE ON PROCEDURE app_public.copy_bound_table_to_stage(VARCHAR) TO APPLIC
 
 -- Store FalkorDB engine version (updated each release via docker_push.sh)
 CREATE TABLE IF NOT EXISTS app_public.app_metadata (key STRING, value STRING);
-MERGE INTO app_public.app_metadata t USING (SELECT 'falkordb_version' AS key, 'text-to-cypher:v0.1.20' AS value) s
+MERGE INTO app_public.app_metadata t USING (SELECT 'falkordb_version' AS key, 'text-to-cypher:v0.2.6' AS value) s
   ON t.key = s.key WHEN MATCHED THEN UPDATE SET value = s.value WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.value);
 GRANT SELECT ON TABLE app_public.app_metadata TO APPLICATION ROLE app_admin;
 GRANT SELECT ON TABLE app_public.app_metadata TO APPLICATION ROLE app_user;

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -400,6 +400,30 @@ BEGIN
     EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.graph_delete(VARCHAR) TO APPLICATION ROLE app_admin';
     EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.graph_delete(VARCHAR) TO APPLICATION ROLE app_user';
 
+    -- Create wrapper procedure for weighted shortest path (algo.SPpaths).
+    -- Returns the single cheapest path between two nodes, minimizing the sum
+    -- of weight_prop along the path instead of just counting hops. The search
+    -- is unbounded in depth and pathCount is fixed at 1: this is the only
+    -- combination where algo.SPpaths uses its fast Dijkstra strategy
+    -- (requires FalkorDB >= 4.20); maxLen or pathCount > 1 fall back to a
+    -- slow enumeration that can stall the service on dense graphs.
+    EXECUTE IMMEDIATE 'CREATE OR REPLACE PROCEDURE app_public.shortest_path(graph_name VARCHAR, node_label VARCHAR, node_prop VARCHAR, source_value VARCHAR, target_value VARCHAR, rel_type VARCHAR, weight_prop VARCHAR)
+        RETURNS STRING
+        LANGUAGE SQL
+        AS
+        ''DECLARE
+            cypher STRING;
+        BEGIN
+            cypher := ''''MATCH (src:'''' || :node_label || '''' {'''' || :node_prop || '''': "'''' || :source_value || ''''"}), (dst:'''' || :node_label || '''' {'''' || :node_prop || '''': "'''' || :target_value || ''''"}) '''' ||
+                      ''''CALL algo.SPpaths({sourceNode: src, targetNode: dst, relTypes: ["'''' || :rel_type || ''''"], weightProp: "'''' || :weight_prop || ''''", pathCount: 1}) '''' ||
+                      ''''YIELD path, pathWeight '''' ||
+                      ''''RETURN pathWeight, [n IN nodes(path) | n.'''' || :node_prop || ''''] AS route'''';
+            RETURN app_public.graph_query_raw({''''graph_name'''': :graph_name, ''''query'''': :cypher});
+        END''';
+
+    EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.shortest_path(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR) TO APPLICATION ROLE app_admin';
+    EXECUTE IMMEDIATE 'GRANT USAGE ON PROCEDURE app_public.shortest_path(VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR, VARCHAR) TO APPLICATION ROLE app_user';
+
     -- Cortex Agent tool functions. Cortex Agents call these as generic tools
     -- from Snowflake; the functions delegate to the app-owned SPCS service.
     EXECUTE IMMEDIATE 'CREATE OR REPLACE FUNCTION agent_tools.get_context(input_agent_name VARCHAR)

--- a/app/src/setup.sql
+++ b/app/src/setup.sql
@@ -135,7 +135,7 @@ GRANT USAGE ON SCHEMA v1 TO APPLICATION ROLE app_admin;
 CREATE OR REPLACE PROCEDURE app_public.request_table_access(table_name VARCHAR)
     RETURNS VARIANT
     LANGUAGE PYTHON
-    RUNTIME_VERSION = '3.8'
+    RUNTIME_VERSION = '3.10'
     PACKAGES = ('snowflake-snowpark-python')
     HANDLER = 'request_access'
     EXECUTE AS OWNER

--- a/docs/SNOWFLAKE_INTEGRATION_GUIDE.md
+++ b/docs/SNOWFLAKE_INTEGRATION_GUIDE.md
@@ -206,6 +206,68 @@ The application needs permission to create the output table:
 GRANT CREATE TABLE ON SCHEMA EXAMPLE_DB.RESULT_SCHEMA TO APPLICATION <app_instance_name>;
 ```
 
+### Weighted Shortest Path
+
+`shortest_path()` wraps FalkorDB's [`algo.SPpaths`](https://docs.falkordb.com/algorithms/sppath.html). Instead of enumerating every path up to N hops, it minimizes the sum of a numeric relationship property (distance, time, price) and returns the single best route:
+
+```sql
+CALL <app_instance_name>.app_public.shortest_path(
+  'airroutes',      -- graph name
+  'Airport',        -- node label
+  'iata_code',      -- node property to match and display
+  'SYD',            -- source value
+  'JFK',            -- target value
+  'ROUTE',          -- relationship type
+  'distance_km'     -- numeric relationship property to minimize
+);
+```
+
+Each result row contains `pathWeight` (total of the minimized property) and `route` (the node property values along the path). The search depth is unbounded: `algo.SPpaths` uses its fast Dijkstra strategy, so even paths needing many hops return in milliseconds.
+
+For advanced options (`costProp`, `maxCost`, `maxLen`, `pathCount`, `relDirection`), call `algo.SPpaths` directly through `graph_query()`. Note that adding a `maxLen` bound or requesting more than one path (`pathCount` > 1) disables the Dijkstra strategy and forces a much slower bounded search; on dense graphs that can stall the service.
+
+The weight can be any numeric relationship property. If your data does not have one yet, derive it with `graph_query()`. For example, compute real route distances from node coordinates (`distance()` returns meters between two `point()` values):
+
+```sql
+CALL <app_instance_name>.app_public.graph_query('airroutes',
+  'MATCH (src:Airport)-[r:ROUTE]->(dst:Airport)
+   SET r.distance_km = round(distance(
+         point({latitude: src.latitude, longitude: src.longitude}),
+         point({latitude: dst.latitude, longitude: dst.longitude})) / 1000)'
+);
+```
+
+For advanced options (`costProp`, `maxCost`, `relDirection`), call `algo.SPpaths` directly through `graph_query()`.
+
+### Node Importance (PageRank)
+
+FalkorDB's [`algo.pageRank`](https://docs.falkordb.com/algorithms/pagerank.html) scores every node by importance: a node ranks high when many other important nodes point to it. The built-in `page_rank()` procedure returns the top nodes, highest first:
+
+```sql
+CALL <app_instance_name>.app_public.page_rank(
+  'airroutes',   -- graph name
+  'Airport',     -- node label
+  'ROUTE',       -- relationship type
+  'iata_code',   -- node property to display
+  10             -- how many top nodes to return
+);
+```
+
+Scores are relative and sum to 1.0 across the graph, so use them for ranking, not as absolute values.
+
+**A real use case:** "A storm is about to close one airport in Europe. Which closure would disrupt global traffic the most?" PageRank answers it instantly: an airport's rank measures how much traffic naturally concentrates there, so rank = impact. It can beat a simple route count, an airport with fewer routes can rank higher because the airports feeding it are themselves major hubs. The same question applies to any domain: which customer, product, server, or account matters most if it fails or gets targeted.
+
+The equivalent raw Cypher, if you need variations, runs through `graph_query()`:
+
+```sql
+CALL <app_instance_name>.app_public.graph_query('airroutes',
+  'CALL algo.pageRank("Airport", "ROUTE")
+   YIELD node, score
+   RETURN node.iata_code AS airport, score
+   ORDER BY score DESC
+   LIMIT 10');
+```
+
 ### Managing Graphs
 
 ```sql

--- a/examples/airroutes/README.md
+++ b/examples/airroutes/README.md
@@ -88,5 +88,86 @@ CALL <app_instance_name>.app_public.graph_query('airroutes',
    LIMIT 20');
 ```
 
+## 7. Weighted shortest path
+
+Enumerating all paths up to N hops tells you what is reachable, not what is best. To find the route that actually matters, put a weight on each edge and let the graph minimize it.
+
+The airports already carry coordinates, so compute the real distance of every route once (FalkorDB's `distance()` returns meters between two `point()` values):
+
+```sql
+CALL <app_instance_name>.app_public.graph_query('airroutes',
+  'MATCH (src:Airport)-[r:ROUTE]->(dst:Airport)
+   SET r.distance_km = round(distance(
+         point({latitude: src.latitude, longitude: src.longitude}),
+         point({latitude: dst.latitude, longitude: dst.longitude})) / 1000)');
+```
+
+Then ask for the shortest route by distance with the built-in `shortest_path()` procedure (a wrapper around FalkorDB's [`algo.SPpaths`](https://docs.falkordb.com/algorithms/sppath.html)):
+
+```sql
+CALL <app_instance_name>.app_public.shortest_path(
+  'airroutes',      -- graph name
+  'Airport',        -- node label
+  'iata_code',      -- node property to match and display
+  'SYD',            -- source value
+  'JFK',            -- target value
+  'ROUTE',          -- relationship type
+  'distance_km'     -- numeric relationship property to minimize
+);
+```
+
+The same thing is available through raw Cypher if you need the advanced options:
+
+```sql
+CALL <app_instance_name>.app_public.graph_query('airroutes',
+  'MATCH (syd:Airport {iata_code:"SYD"}), (jfk:Airport {iata_code:"JFK"})
+   CALL algo.SPpaths({
+     sourceNode: syd,
+     targetNode: jfk,
+     relTypes: ["ROUTE"],
+     weightProp: "distance_km",
+     pathCount: 1
+   })
+   YIELD path, pathWeight
+   RETURN pathWeight AS total_km,
+          [airport IN nodes(path) | airport.iata_code] AS route');
+```
+
+Instead of 20 arbitrary 5-hop itineraries, this returns the single best route ranked by total kilometers flown. The search depth is unbounded: without a `maxLen` restriction `algo.SPpaths` uses its fast Dijkstra strategy, so even remote routes needing many hops return in milliseconds. Useful variations:
+
+- `weightProp: "stops"` minimizes layovers instead of distance
+- `costProp` + `maxCost` minimizes one property while bounding another (for example, shortest distance with at most 2 stops)
+
+Keep `pathCount: 1` and avoid `maxLen`: either of those switches the engine to a slow bounded search that can stall on dense graphs.
+
+## 8. Rank the biggest hubs (PageRank)
+
+Which airports matter most in the network? PageRank scores each airport by how much traffic naturally concentrates there: an airport ranks high when many well-connected airports route into it. Unlike shortest path, it needs no weights and no source/target, it looks at the whole network at once. Use the built-in `page_rank()` procedure:
+
+```sql
+CALL <app_instance_name>.app_public.page_rank(
+  'airroutes',   -- graph name
+  'Airport',     -- node label
+  'ROUTE',       -- relationship type
+  'iata_code',   -- node property to display
+  10             -- how many top nodes to return
+);
+```
+
+Returns the top 10 hub airports with their PageRank scores, highest first. Scores are relative (they sum to 1.0 across the graph), so read them as a ranking.
+
+A real question this answers: "a storm is about to close one airport, which closure disrupts global traffic the most?" The rank measures impact, and it can beat a simple route count: ATL and ORD rank above FRA and CDG even though the latter have more routes, because the airports feeding them are themselves major hubs.
+
+The same is available as raw Cypher through `graph_query()` if you need variations:
+
+```sql
+CALL <app_instance_name>.app_public.graph_query('airroutes',
+  'CALL algo.pageRank("Airport", "ROUTE")
+   YIELD node, score
+   RETURN node.iata_code AS airport, score
+   ORDER BY score DESC
+   LIMIT 10');
+```
+
 For the full walkthrough (including the SQL comparison and Cortex Agent setup), see the
 [Snowflake integration guide](https://docs.falkordb.com/integration/snowflake.html).

--- a/examples/airroutes/USECASES.md
+++ b/examples/airroutes/USECASES.md
@@ -1,0 +1,37 @@
+# Air Routes Use Cases
+
+Two graph algorithm use cases on the air routes demo, runnable straight from Snowflake.
+
+## 1. Cheapest route: weighted shortest path
+
+**Story:** A passenger flies Sydney (SYD) to New York (JFK). What is the route with the fewest total kilometers, including every stop along the way?
+
+```sql
+CALL <app_instance_name>.app_public.shortest_path(
+  'airroutes',      -- graph name
+  'Airport',        -- node label
+  'iata_code',      -- node property
+  'SYD',            -- source
+  'JFK',            -- target
+  'ROUTE',          -- relationship type
+  'distance_km'     -- property to minimize
+);
+```
+
+Returns the total distance (`pathWeight`) and the ordered list of airports on the cheapest path.
+
+## 2. Route planning: PageRank
+
+**Story:** An airline is planning a new route. Which airport gives the best connectivity for onward flights? PageRank scores airports by how well they connect to other well-connected hubs, so passengers landing there can reach anywhere in one hop. The same ranking works for risk analysis: whose closure would disrupt the network most?
+
+```sql
+CALL <app_instance_name>.app_public.page_rank(
+  'airroutes',   -- graph name
+  'Airport',     -- node label
+  'ROUTE',       -- relationship type
+  'iata_code',   -- property to show per node
+  10             -- top N results
+);
+```
+
+Returns the 10 highest-ranked airports with their scores, most important first.

--- a/scripts/docker_push.sh
+++ b/scripts/docker_push.sh
@@ -29,7 +29,7 @@ snow spcs image-registry login --connection myconnection || {
 
 echo "✅ Successfully logged into Docker registry!"
 
-FALKORDB_IMAGE="text-to-cypher:v0.1.20"          # source image to pull
+FALKORDB_IMAGE="text-to-cypher:v0.2.6"           # source image to pull
 TARGET_IMAGE_NAME="falkordb_server"              # image name expected by falkordb.yml
 TARGET_TAG="latest"                              # falkordb.yml has no tag -> defaults to 'latest'
 


### PR DESCRIPTION
## What's in this patch

### Timeout bug fix (the main event)
- Upgrade bundled image to **text-to-cypher v0.2.6**, which ships falkordb-rs 0.10.3: removes the client-side 500ms response timeout (inherited from redis-rs 1.0) that failed any query over 500ms with "connection error... should probably be retried in a bit" while the server kept executing, causing duplicate data on retry (fixed in FalkorDB/falkordb-rs#297, released via FalkorDB/text-to-cypher#178)
- Set **server-side query timeouts** in both service specs (falkordb.yaml + inline spec in setup.sql): TIMEOUT_DEFAULT 60s so large loads succeed, TIMEOUT_MAX 120s to cap runaway queries

### New graph algorithm procedures
- `app_public.shortest_path(...)`: weighted shortest path via algo.SPpaths (Dijkstra), minimizing a numeric relationship property
- `app_public.page_rank(...)`: top-N node importance ranking via algo.pageRank
- Documented in app readme, integration guide, and airroutes example incl. a new USECASES.md

### Chores
- request_table_access Python runtime 3.8 → 3.10
- falkordb_version metadata → v0.2.6
- manifest → patch 48

## Validation
- Local E2E with the released v0.2.6 image: the exact 428k-row load_csv repro that failed on patch 45/46 at ~550ms now completes in 1.6s with exactly 428,460 nodes; a 4.6s query succeeds
- Deployed to FALKORDB_QA_TEST as V2 patch 48 and verified